### PR TITLE
3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/browserslist-config",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/browserslist-config",
-      "version": "2.3.0",
+      "version": "3.0.0",
       "license": "GPL-3.0-or-later"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/browserslist-config",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Shared browserslist for Nextcloud libraries and apps",
   "main": "browserlist.config.js",
   "scripts": {


### PR DESCRIPTION
## What's Changed

We now supports node `^20.0.0` and npm `^9.0.0`

* Removed IE 11 since it's already dead by @skjnldsv in https://github.com/nextcloud/browserslist-config/pull/8
* Update node engines to next LTS by @nextcloud-command in https://github.com/nextcloud/browserslist-config/pull/11


**Full Changelog**: https://github.com/nextcloud/browserslist-config/compare/v2.3.0...v3.0.0

close #12 