### PR TITLE
Support Safari 15.5

### DIFF
--- a/browserlist.config.js
+++ b/browserlist.config.js
@@ -3,4 +3,5 @@ module.exports = [
   'not op_mini all',
   'not dead',
   'Firefox ESR',
+  'Safari 15.5',
 ];


### PR DESCRIPTION
Hello @jancborchardt 
Hi @ChristophWurst 

In Global, Safari 15.6 is 0.30%.
Safari 15.5 is 0.04 %.

Some designers don't update quickly MacOS because they fear the design softwares (Adobe CC for example) they are using might break or bug too heavily for a good reason: it has happened for them in the past. Therefore, they could even fear minor updates of anything: Safari for example. I don't think the "0.25%" threshold should be reduced as it could make the whole thing bloated, but we could be more considerate for designers that fear updates and work disruption.
And we could do that by including the Safari version that is just before the Safari version above the 0.25% threshold, which is at this time: Safari 15.5.