### PR TITLE
fix: add minimal supported browserslist version to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
+      },
+      "peerDependencies": {
+        "browserslist": "^4.26.3"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "browserslist": "^4.26.3",
     "browserslist-useragent-regexp": "^4.1.3"
+  },
+  "peerDependencies": {
+    "browserslist": "^4.26.3"
   }
 }


### PR DESCRIPTION
- We specify `baseline` since https://github.com/nextcloud-libraries/browserslist-config/pull/23
- `baseline` support was added in 4.26.0, then there were some related fixes
  - https://github.com/browserslist/browserslist/releases
- Require `4.26.3` as a peer dependency