### PR TITLE
chore: manually lint

### DIFF
--- a/__tests__/browserslist.test.mjs
+++ b/__tests__/browserslist.test.mjs
@@ -1,10 +1,11 @@
-/**
+/*
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import browserslistConfig from '../browserslist.config.js'
+
 import browserslist from 'browserslist'
 import { getUserAgentRegex } from 'browserslist-useragent-regexp'
+import browserslistConfig from '../browserslist.config.js'
 
 // Generate a regex that matches user agents to detect incompatible browsers
 const supportedBrowsersRegExp = getUserAgentRegex({ allowHigherVersions: true, browsers: browserslistConfig })
@@ -13,4 +14,3 @@ const supportedBrowsers = browserslist(browserslistConfig)
 // Log the results
 console.log('Supported browsers regex for Nextcloud Web:', supportedBrowsersRegExp)
 console.log('Supported browsers for Nextcloud Web:', supportedBrowsers.join(', '))
-

--- a/browserslist.config.js
+++ b/browserslist.config.js
@@ -1,11 +1,12 @@
-/**
+/*
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
 module.exports = [
-  'defaults',
-  'not op_mini all',
-  'not dead',
-  'Firefox ESR',
-  'baseline widely available',
-];
+	'defaults',
+	'not op_mini all',
+	'not dead',
+	'Firefox ESR',
+	'baseline widely available',
+]

--- a/package.json
+++ b/package.json
@@ -2,24 +2,20 @@
   "name": "@nextcloud/browserslist-config",
   "version": "3.1.1",
   "description": "Shared browserslist for Nextcloud libraries and apps",
-  "main": "browserslist.config.js",
-  "scripts": {
-    "test": "node __tests__/browserslist.test.mjs"
-  },
   "keywords": [
     "nextcloud",
     "browserslist"
   ],
   "homepage": "https://github.com/nextcloud/browserslist-config#readme",
-  "author": "Christoph Wurst",
-  "license": "GPL-3.0-or-later",
   "repository": {
     "type": "git",
     "url": "https://github.com/nextcloud/browserslist-config"
   },
-  "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+  "license": "GPL-3.0-or-later",
+  "author": "Christoph Wurst",
+  "main": "browserslist.config.js",
+  "scripts": {
+    "test": "node __tests__/browserslist.test.mjs"
   },
   "devDependencies": {
     "browserslist": "^4.26.3",
@@ -27,5 +23,9 @@
   },
   "peerDependencies": {
     "browserslist": "^4.26.3"
+  },
+  "engines": {
+    "node": "^20.0.0",
+    "npm": "^10.0.0"
   }
 }


### PR DESCRIPTION
Manually lint the code:
- Use tabs
- No semicolon
- No JSDoc as copyright
- No extra blank lines
- Sort imports
- Sort package.json

ESLint is not installed because it is much larger than the library code...