### PR TITLE
fix: adjust config to support only active or used browsers

### DIFF
--- a/browserslist.config.js
+++ b/browserslist.config.js
@@ -4,9 +4,7 @@
  */
 
 module.exports = [
-	'defaults',
-	'not op_mini all',
-	'not dead',
-	'Firefox ESR',
-	'baseline widely available',
+	'baseline widely available with downstream and last 4 major versions and not dead',
+	'baseline widely available with downstream and >0.25% and not dead',
+	'firefox esr'
 ]

--- a/browserslist.config.js
+++ b/browserslist.config.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = [
-	'baseline widely available with downstream and last 4 major versions and not dead',
-	'baseline widely available with downstream and >0.25% and not dead',
+	'baseline widely available with downstream and last 2 major versions and not dead',
+	'baseline widely available with downstream and >0.05% and not dead',
 	'firefox esr'
 ]


### PR DESCRIPTION
Refine configuration as v3.1.0 introduced a bunch of previously not supported *old* browsers that cause heavily increased bundle sizes. This instead goes back to what 3.0.1 had (>0.25% usage) but also includes new browsers (what 3.1.0 wanted to fix) that are not yet used by >0.25% of users.

So we support:
- Always Firefox ESR
- Browsers (and their forks like Edge) that support "baseline widely available"
  - If they are new (last 4 major versions)
  - Or still used by >0.25% of the market
  - And in both cases are not dead